### PR TITLE
fix: graceful degradation when plugin not found

### DIFF
--- a/paper/src/main/java/net/sabafly/mailBox/database/UserConverter.java
+++ b/paper/src/main/java/net/sabafly/mailBox/database/UserConverter.java
@@ -30,7 +30,12 @@ public class UserConverter {
         if (baseUser == null) {
             return null;
         }
-        return baseUser.toUser(uuid, key);
+        try {
+            return baseUser.toUser(uuid, key);
+        } catch (IllegalStateException e) {
+            // Plugin not found or other state issues - return null gracefully
+            return null;
+        }
     }
 
     public static byte @NotNull [] toJson(@NotNull User user) {

--- a/paper/src/main/java/net/sabafly/mailBox/database/impl/Base.java
+++ b/paper/src/main/java/net/sabafly/mailBox/database/impl/Base.java
@@ -323,13 +323,19 @@ public abstract class Base implements Database {
                         UUID id = UUID.fromString(rs.getString("id"));
                         UUID senderId = Optional.ofNullable(rs.getString("sender")).map(UUID::fromString).orElse(DummyMailUser.SYSTEM_UUID);
                         User sender = getUser(senderId);
+                        if (sender == null) {
+                            sender = DummyMailUser.createUser(senderId, "Unknown Sender", "unknown", null);
+                        }
                         UUID receiverId = UUID.fromString(rs.getString("receiver"));
                         User receiver = getUser(receiverId);
+                        if (receiver == null) {
+                            receiver = DummyMailUser.createUser(receiverId, "Unknown Receiver", "unknown", null);
+                        }
                         String title = rs.getString("title");
                         String content = rs.getString("content");
                         boolean isRead = rs.getBoolean("is_read");
                         LocalDateTime sentTime = rs.getTimestamp("sentTime").toLocalDateTime();
-                        Mail mail = new Mail(id, Objects.requireNonNull(sender), Objects.requireNonNull(receiver), title, content, List.of(), isRead, sentTime);
+                        Mail mail = new Mail(id, sender, receiver, title, content, List.of(), isRead, sentTime);
                         mail.attachments(getMailAttachments(mail));
                         mails.add(mail);
                     }
@@ -344,13 +350,19 @@ public abstract class Base implements Database {
                         UUID id = UUID.fromString(rs.getString("id"));
                         UUID senderId = Optional.ofNullable(rs.getString("sender")).map(UUID::fromString).orElse(DummyMailUser.SYSTEM_UUID);
                         User sender = getUser(senderId);
+                        if (sender == null) {
+                            sender = DummyMailUser.createUser(senderId, "Unknown Sender", "unknown", null);
+                        }
                         UUID receiverId = UUID.fromString(rs.getString("receiver"));
                         User receiver = getUser(receiverId);
+                        if (receiver == null) {
+                            receiver = DummyMailUser.createUser(receiverId, "Unknown Receiver", "unknown", null);
+                        }
                         String title = rs.getString("title");
                         String content = rs.getString("content");
                         boolean isRead = rs.getBoolean("is_read");
                         LocalDateTime sentTime = rs.getTimestamp("sentTime").toLocalDateTime();
-                        Mail mail = new Mail(id, Objects.requireNonNull(sender), Objects.requireNonNull(receiver), title, content, List.of(), isRead, sentTime);
+                        Mail mail = new Mail(id, sender, receiver, title, content, List.of(), isRead, sentTime);
                         mail.attachments(getMailAttachments(mail));
                         mails.add(mail);
                     }
@@ -396,13 +408,19 @@ public abstract class Base implements Database {
                 if (rs.next()) {
                     UUID senderId = Optional.ofNullable(rs.getString("sender")).map(UUID::fromString).orElse(DummyMailUser.SYSTEM_UUID);
                     User sender = getUser(senderId);
+                    if (sender == null) {
+                        sender = DummyMailUser.createUser(senderId, "Unknown Sender", "unknown", null);
+                    }
                     UUID receiverId = UUID.fromString(rs.getString("receiver"));
                     User receiver = getUser(receiverId);
+                    if (receiver == null) {
+                        receiver = DummyMailUser.createUser(receiverId, "Unknown Receiver", "unknown", null);
+                    }
                     String title = rs.getString("title");
                     String content = rs.getString("content");
                     boolean read = rs.getBoolean("is_read");
                     LocalDateTime sentTime = rs.getTimestamp("sentTime").toLocalDateTime();
-                    Mail mail = new Mail(id, Objects.requireNonNull(sender), Objects.requireNonNull(receiver), title, content, List.of(), read, sentTime);
+                    Mail mail = new Mail(id, sender, receiver, title, content, List.of(), read, sentTime);
                     mail.attachments(getMailAttachments(mail));
                     return mail;
                 }
@@ -490,11 +508,14 @@ public abstract class Base implements Database {
                     boolean autoSend = rs.getBoolean("auto_send");
                     UUID senderId = Optional.ofNullable(rs.getString("sender")).map(UUID::fromString).orElse(null);
                     User sender = getUser(senderId);
+                    if (sender == null) {
+                        sender = DummyMailUser.createUser(senderId != null ? senderId : DummyMailUser.SYSTEM_UUID, "Unknown Sender", "unknown", null);
+                    }
                     Date startTime = rs.getTimestamp("start_time");
                     Date endTime = rs.getTimestamp("end_time");
                     Duration interval = Optional.of(rs.getLong("send_interval")).filter(l -> l > 0).map(Duration::ofSeconds).orElse(null);
                     String permission = rs.getString("permission");
-                    MailTemplate template = new MailTemplate(id, title, content, List.of(), autoSend, Objects.requireNonNull(sender), LocalDateTime.ofInstant(startTime.toInstant(), ZoneId.systemDefault()), LocalDateTime.ofInstant(endTime.toInstant(), ZoneId.systemDefault()), interval, permission);
+                    MailTemplate template = new MailTemplate(id, title, content, List.of(), autoSend, sender, LocalDateTime.ofInstant(startTime.toInstant(), ZoneId.systemDefault()), LocalDateTime.ofInstant(endTime.toInstant(), ZoneId.systemDefault()), interval, permission);
                     template.setAttachment(getTemplateAttachments(template));
                     return template;
                 }
@@ -520,11 +541,14 @@ public abstract class Base implements Database {
                     boolean autoSend = rs.getBoolean("auto_send");
                     UUID senderId = Optional.ofNullable(rs.getString("sender")).map(UUID::fromString).orElse(null);
                     User sender = getUser(senderId);
+                    if (sender == null) {
+                        sender = DummyMailUser.createUser(senderId != null ? senderId : DummyMailUser.SYSTEM_UUID, "Unknown Sender", "unknown", null);
+                    }
                     @Nullable LocalDateTime startTime = Optional.ofNullable(rs.getTimestamp("start_time")).map(timestamp -> LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault())).orElse(null);
                     @Nullable LocalDateTime endTime = Optional.ofNullable(rs.getTimestamp("end_time")).map(timestamp -> LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault())).orElse(null);
                     @Nullable Duration interval = Optional.of(rs.getLong("send_interval")).filter(l -> l > 0).map(Duration::ofSeconds).orElse(null);
                     @Nullable String permission = rs.getString("permission");
-                    MailTemplate template = new MailTemplate(id, title, content, List.of(), autoSend, Objects.requireNonNull(sender), startTime, endTime, interval, permission);
+                    MailTemplate template = new MailTemplate(id, title, content, List.of(), autoSend, sender, startTime, endTime, interval, permission);
                     template.setAttachment(getTemplateAttachments(template));
                     templates.add(template);
                 }
@@ -550,11 +574,14 @@ public abstract class Base implements Database {
                     boolean autoSend = rs.getBoolean("auto_send");
                     UUID senderId = Optional.ofNullable(rs.getString("sender")).map(UUID::fromString).orElse(null);
                     User sender1 = getUser(senderId);
+                    if (sender1 == null) {
+                        sender1 = DummyMailUser.createUser(senderId != null ? senderId : DummyMailUser.SYSTEM_UUID, "Unknown Sender", "unknown", null);
+                    }
                     @Nullable LocalDateTime startTime = Optional.ofNullable(rs.getTimestamp("start_time")).map(timestamp -> LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault())).orElse(null);
                     @Nullable LocalDateTime endTime = Optional.ofNullable(rs.getTimestamp("end_time")).map(timestamp -> LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault())).orElse(null);
                     @Nullable Duration interval = Optional.of(rs.getLong("send_interval")).filter(l -> l > 0).map(Duration::ofSeconds).orElse(null);
                     @Nullable String permission = rs.getString("permission");
-                    MailTemplate template = new MailTemplate(id, title, content, List.of(), autoSend, Objects.requireNonNull(sender1), startTime, endTime, interval, permission);
+                    MailTemplate template = new MailTemplate(id, title, content, List.of(), autoSend, sender1, startTime, endTime, interval, permission);
                     template.setAttachment(getTemplateAttachments(template));
                     templates.add(template);
                 }
@@ -580,11 +607,14 @@ public abstract class Base implements Database {
                     boolean autoSend = rs.getBoolean("auto_send");
                     UUID senderId = Optional.ofNullable(rs.getString("sender")).map(UUID::fromString).orElse(DummyMailUser.SYSTEM_UUID);
                     User sender = getUser(senderId);
+                    if (sender == null) {
+                        sender = DummyMailUser.createUser(senderId, "Unknown Sender", "unknown", null);
+                    }
                     @Nullable LocalDateTime startTime = rs.getTimestamp("start_time") == null ? null : LocalDateTime.ofInstant(rs.getTimestamp("start_time").toInstant(), ZoneId.systemDefault());
                     @Nullable LocalDateTime endTime = rs.getTimestamp("end_time") == null ? null : LocalDateTime.ofInstant(rs.getTimestamp("end_time").toInstant(), ZoneId.systemDefault());
                     @Nullable Duration interval = Optional.of(rs.getLong("send_interval")).filter(l -> l > 0).map(Duration::ofSeconds).orElse(null);
                     @Nullable String permission = rs.getString("permission");
-                    MailTemplate template = new MailTemplate(id, title, content, List.of(), autoSend, Objects.requireNonNull(sender), startTime, endTime, interval, permission);
+                    MailTemplate template = new MailTemplate(id, title, content, List.of(), autoSend, sender, startTime, endTime, interval, permission);
                     template.setAttachment(getTemplateAttachments(template));
                     templates.add(template);
                 }


### PR DESCRIPTION
## Problem
When a plugin that registered a `PluginMailUser` is not loaded (e.g., disabled or uninstalled), MailBox throws `IllegalStateException: Plugin not found for namespace: xxx` and crashes when trying to view mails/templates.

## Solution
Gracefully degrade to `DummyMailUser` instead of crashing:

1. **UserConverter.readUser**: Catch `IllegalStateException` from `PluginUser.toUser()` and return `null`
2. **Base.getMails/getMail**: Handle null sender/receiver by creating fallback `DummyMailUser`
3. **Base.getMailTemplate(s)**: Handle null sender by creating fallback `DummyMailUser`

## Use Case
This commonly happens when:
- A plugin is temporarily disabled
- A plugin is uninstalled but its data remains in the database
- Server operators switch between different plugins

## Testing
Tested with TransferStation plugin disabled - MailBox now shows "Unknown Sender/Receiver" instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 関連ユーザーが見つからないメールやテンプレートを取得する際に、エラーが発生する問題を修正しました。
  * 状態不整合や利用できない連携先がある場合も、処理が中断せず安全に扱えるようになりました。
  * 該当ユーザー情報が存在しない場合は、代替ユーザー情報を用いてメールやテンプレートを表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->