### PR TITLE
feat: shift+click claim all, ESC close, notification toggle

### DIFF
--- a/paper/src/main/java/net/sabafly/mailBox/menu/InboxMenu.java
+++ b/paper/src/main/java/net/sabafly/mailBox/menu/InboxMenu.java
@@ -109,7 +109,17 @@ public class InboxMenu extends InventoryMenu<InboxMenu> {
         database().deleteAllUserNotification(owner);
         for (Mail mail : database().getMails(owner, TriState.NOT_SET, page).stream().sorted().toList().reversed()) {
             clickRegistry.setItem(slot, createMailItem(mail), (_, clickType) -> {
-                if (clickType.isLeftClick()) {
+                if (clickType.isShiftClick() && clickType.isLeftClick()) {
+                    // Shift+左键：一键领取该邮件所有附件
+                    for (var attachment : mail.getAttachmentsInternal()) {
+                        if (attachment.canOpen()) {
+                            attachment.apply(viewer);
+                            attachment.setOpened(true);
+                            database().updateMailAttachment(mail, attachment);
+                        }
+                    }
+                    refresh();
+                } else if (clickType.isLeftClick()) {
 //                    ThreadUtils.runSync(viewer, () -> new MailDialogView(viewer, this, mail, owner).open());
                     openMenu(new MailViewerMenu(viewer, owner, mail, true));
                 } else if (clickType.isRightClick() && mail.getAttachmentsInternal().stream().allMatch(a -> a.opened() || a.isExpired())) {
@@ -152,6 +162,10 @@ public class InboxMenu extends InventoryMenu<InboxMenu> {
                     .transform(s -> Stream.of(s.split("\n")))
                     .filter(s -> !s.isBlank()).map(miniMessage()::deserialize)
                     .collect(Collectors.toCollection(ArrayList::new));
+            long claimable = mail.getAttachmentsInternal().stream().filter(a -> a.canOpen()).count();
+            if (claimable > 0) {
+                lore.addFirst(miniMessage().deserialize(config().messages.shiftLeftClickTo.replace("{action}", config().messages.clickActionClaimAll)));
+            }
             lore.addFirst(miniMessage().deserialize(config().messages.rightClickTo.replace("{action}", config().messages.clickActionDelete)));
             lore.addFirst(miniMessage().deserialize(config().messages.leftClickTo.replace("{action}", config().messages.clickActionOpen)));
             meta.lore(lore);

--- a/paper/src/main/java/net/sabafly/mailBox/menu/MailViewerMenu.java
+++ b/paper/src/main/java/net/sabafly/mailBox/menu/MailViewerMenu.java
@@ -63,9 +63,7 @@ public class MailViewerMenu extends InventoryMenu<MailViewerMenu> {
 
     @Override
     protected void onClose(@NotNull Player player, @Nullable InventoryView inventory) {
-        if (openPreviousMenu) {
-            setNextMenu(new InboxMenu(player, owner));
-        }
+        // ESC直接关闭，不强制弹回收件箱
     }
 
     @Override

--- a/paper/src/main/java/net/sabafly/mailBox/schedule/ScheduleManager.java
+++ b/paper/src/main/java/net/sabafly/mailBox/schedule/ScheduleManager.java
@@ -73,6 +73,7 @@ public class ScheduleManager {
     }
 
     public static void checkNotify(Player player, PlayerMailUser user, boolean login) {
+        if (!config().enableMailNotification) return;
         boolean notified = false;
         try {
             if (login) {


### PR DESCRIPTION
## UI Improvements

### Shift+Left Click Claim All Attachments
- Shift+左键一键领取邮件所有附件
- New config messages:
  - shiftLeftClickTo: "<gray>Shift+Left Click to {action}</gray>"
  - clickActionClaimAll: "<green>Claim All Attachments</green>"
- Lore shows claim hint when mail has unclaimed attachments

### ESC Close Behavior
- MailViewerMenu: ESC直接关闭，不强制弹回收件箱
- Previous behavior: onClose always opened InboxMenu
- New behavior: onClose does nothing, player returns to previous state

### Mail Notification Toggle
- New config option: enableMailNotification (default: false)
- ScheduleManager.checkNotify respects this setting
- When false, no login/join mail notifications shown

## Use Cases
- Quickly claim all attachments from reward mails
- More natural ESC behavior (close = close, not navigate)
- Disable notifications for servers with frequent automated mails